### PR TITLE
Fix support for multple Coveys on the same Exchange.

### DIFF
--- a/src/main/java/io/vlingo/lattice/exchange/camel/CoveyFactory.java
+++ b/src/main/java/io/vlingo/lattice/exchange/camel/CoveyFactory.java
@@ -10,15 +10,14 @@ package io.vlingo.lattice.exchange.camel;
 import io.vlingo.lattice.exchange.Covey;
 import io.vlingo.lattice.exchange.ExchangeReceiver;
 import io.vlingo.lattice.exchange.ExchangeSender;
-import io.vlingo.lattice.exchange.camel.sender.ExchangeSenders;
-import org.apache.camel.CamelContext;
+import io.vlingo.lattice.exchange.camel.adapter.AbstractCamelExchangeAdapter;
 import org.apache.camel.Exchange;
 
 /**
  * A factory that produces Exchange {@code io.vlingo.lattice.exchange.Covey} instances to be used with {@code io.vlingo.lattice.exchange.camel.CamelExchange}.
  */
 public final class CoveyFactory {
-  private CoveyFactory(){
+  private CoveyFactory() {
     //prevent instantiation
   }
 
@@ -28,13 +27,8 @@ public final class CoveyFactory {
    * @param <L> the local object type
    * @param <E> the external object type
    */
-  public static <L, E> Covey<L, E, Exchange> build(CamelContext camelContext, String endpoint,
-                                                 final ExchangeReceiver<L> receiver,
-                                                 final CamelExchangeAdapter<L, E> adapter,
-                                                 final Class<L> localClass,
-                                                 final Class<E> externalClass) throws Exception {
-
-    final ExchangeSender<Exchange> sender = ExchangeSenders.sendingTo(endpoint, camelContext);
+  public static <L, E> Covey<L, E, Exchange> build(final ExchangeSender<Exchange> sender, final ExchangeReceiver<L> receiver,
+                                                   final AbstractCamelExchangeAdapter<L, E> adapter, final Class<L> localClass, final Class<E> externalClass) {
 
     return new Covey<>(sender, receiver, adapter, localClass, externalClass, Exchange.class);
   }

--- a/src/main/java/io/vlingo/lattice/exchange/camel/adapter/JsonCamelExchangeAdapter.java
+++ b/src/main/java/io/vlingo/lattice/exchange/camel/adapter/JsonCamelExchangeAdapter.java
@@ -1,0 +1,29 @@
+// Copyright © 2012-2018 Vaughn Vernon. All rights reserved.
+//
+// This Source Code Form is subject to the terms of the
+// Mozilla Public License, v. 2.0. If a copy of the MPL
+// was not distributed with this file, You can obtain
+// one at https://mozilla.org/MPL/2.0/.
+package io.vlingo.lattice.exchange.camel.adapter;
+
+import io.vlingo.common.serialization.JsonSerialization;
+import org.apache.camel.CamelContext;
+import org.apache.camel.Exchange;
+import org.apache.camel.builder.ExchangeBuilder;
+
+public class JsonCamelExchangeAdapter<L, E> extends AbstractCamelExchangeAdapter<L, E> {
+  
+  public JsonCamelExchangeAdapter(final CamelContext camelContext, final Class<L> localMessageClass) {
+    super(camelContext, localMessageClass);
+  }
+
+  @Override
+  protected ExchangeBuilder buildExchange(final ExchangeBuilder builder, final L localMessage) {
+    return builder.withBody(JsonSerialization.serialized(localMessage));
+  }
+
+  @Override
+  public L fromExchange(final Exchange exchangeMessage) {
+    return JsonSerialization.deserialized(exchangeMessage.getMessage().getBody(String.class), localMessageClass());
+  }
+}

--- a/src/test/java/io/vlingo/lattice/exchange/TextMessageAdapter.java
+++ b/src/test/java/io/vlingo/lattice/exchange/TextMessageAdapter.java
@@ -1,17 +1,16 @@
 package io.vlingo.lattice.exchange;
 
-import io.vlingo.lattice.exchange.camel.CamelExchangeAdapter;
+import io.vlingo.lattice.exchange.camel.adapter.AbstractCamelExchangeAdapter;
 import org.apache.camel.CamelContext;
 import org.apache.camel.Exchange;
 import org.apache.camel.builder.ExchangeBuilder;
 
-public class TextMessageAdapter extends CamelExchangeAdapter<String, String> {
-  public TextMessageAdapter(final CamelContext camelContext) {super(camelContext);}
+public class TextMessageAdapter extends AbstractCamelExchangeAdapter<String, String> {
+  public TextMessageAdapter(final CamelContext camelContext) {super(camelContext, String.class);}
 
   @Override
   public String fromExchange(final Exchange exchangeMessage) {
-    return exchangeMessage.getMessage()
-                          .getBody(String.class);
+    return exchangeMessage.getMessage().getBody(String.class);
   }
 
   @Override

--- a/src/test/java/io/vlingo/lattice/exchange/camel/CamelTestWithDockerIntegration.java
+++ b/src/test/java/io/vlingo/lattice/exchange/camel/CamelTestWithDockerIntegration.java
@@ -9,7 +9,10 @@ package io.vlingo.lattice.exchange.camel;
 
 import io.vlingo.lattice.exchange.Covey;
 import io.vlingo.lattice.exchange.Exchange;
+import io.vlingo.lattice.exchange.ExchangeSender;
 import io.vlingo.lattice.exchange.TextMessageAdapter;
+import io.vlingo.lattice.exchange.camel.e2e.MockMessageReceiver;
+import io.vlingo.lattice.exchange.camel.sender.ExchangeSenders;
 import org.apache.camel.CamelContext;
 import org.junit.Assert;
 import org.junit.jupiter.api.AfterEach;
@@ -21,48 +24,52 @@ import java.util.Queue;
 import java.util.UUID;
 
 public abstract class CamelTestWithDockerIntegration<T extends GenericContainer> extends CamelTest {
-    private T container;
+  private T container;
 
-    protected abstract T testContainer();
-    protected abstract String exchangeUri(T forContainer);
+  protected abstract T testContainer();
 
-    @BeforeEach
-    public void initializeContainer() {
-        container = testContainer();
-        container.start();
+  protected abstract String exchangeUri(T forContainer);
+
+  @BeforeEach
+  public void initializeContainer() {
+    container = testContainer();
+    container.start();
+  }
+
+  @AfterEach
+  public void tearDownContainer() {
+    container.stop();
+  }
+
+  @Test
+  public void shouldConsumeAndReadTheSameMessageFromTheSameExchange() throws Exception {
+    String exchangeUri = exchangeUri(container);
+    final CamelContext camelContext = context();
+    Exchange exchange = new CamelExchange(context(), exchangeUri, exchangeUri);
+
+    try {
+      final MockMessageReceiver<String> messageReceiver = new MockMessageReceiver<>(2);
+
+      final ExchangeSender<org.apache.camel.Exchange> sender = ExchangeSenders.sendingTo(exchangeUri, camelContext);
+
+      final Covey<String, String, org.apache.camel.Exchange> covey = CoveyFactory.build(sender,
+                                                                                        messageReceiver,
+                                                                                        new TextMessageAdapter(camelContext),
+                                                                                        String.class,
+                                                                                        String.class);
+      exchange.register(covey);
+
+      final String msg1 = UUID.randomUUID().toString();
+      final String msg2 = UUID.randomUUID().toString();
+      exchange.send(msg1);
+      exchange.send(msg2);
+
+      final Queue<String> results = messageReceiver.getResults();
+      Assert.assertEquals(2, results.size());
+      Assert.assertEquals(msg1, results.poll());
+      Assert.assertEquals(msg2, results.poll());
+    } finally {
+      exchange.close();
     }
-
-    @AfterEach
-    public void tearDownContainer() {
-        container.stop();
-    }
-
-    @Test
-    public void shouldConsumeAndReadTheSameMessageFromTheSameExchange() throws Exception {
-        String exchangeUri = exchangeUri(container);
-        final CamelContext camelContext = context();
-        Exchange exchange = new CamelExchange(context(), exchangeUri, exchangeUri);
-
-        try {
-            final TextMessageReceiver messageReceiver = new TextMessageReceiver(2);
-
-            final Covey<String, String, org.apache.camel.Exchange> covey = CoveyFactory.build(camelContext, exchangeUri,
-                                                                                              messageReceiver,
-                                                                                              new TextMessageAdapter(camelContext),
-                                                                                              String.class, String.class);
-            exchange.register(covey);
-
-            final String msg1 = UUID.randomUUID().toString();
-            final String msg2 = UUID.randomUUID().toString();
-            exchange.send(msg1);
-            exchange.send(msg2);
-
-            final Queue<Object> results = messageReceiver.getResults();
-            Assert.assertEquals(2, results.size());
-            Assert.assertEquals(msg1, results.poll());
-            Assert.assertEquals(msg2, results.poll());
-        } finally {
-            exchange.close();
-        }
-    }
+  }
 }

--- a/src/test/java/io/vlingo/lattice/exchange/camel/e2e/CamelExchangeTest.java
+++ b/src/test/java/io/vlingo/lattice/exchange/camel/e2e/CamelExchangeTest.java
@@ -9,49 +9,105 @@ package io.vlingo.lattice.exchange.camel.e2e;
 
 import io.vlingo.lattice.exchange.Covey;
 import io.vlingo.lattice.exchange.Exchange;
+import io.vlingo.lattice.exchange.ExchangeSender;
 import io.vlingo.lattice.exchange.TextMessageAdapter;
 import io.vlingo.lattice.exchange.camel.CamelExchange;
 import io.vlingo.lattice.exchange.camel.CamelTest;
 import io.vlingo.lattice.exchange.camel.CoveyFactory;
-import io.vlingo.lattice.exchange.camel.TextMessageReceiver;
+import io.vlingo.lattice.exchange.camel.e2e.model.MessageTypeA;
+import io.vlingo.lattice.exchange.camel.e2e.model.MessageTypeB;
+import io.vlingo.lattice.exchange.camel.e2e.model.MessageTypeC;
+import io.vlingo.lattice.exchange.camel.sender.ExchangeSenders;
 import org.apache.camel.CamelContext;
 import org.junit.Assert;
 import org.junit.jupiter.api.Test;
 
 import java.util.Queue;
+import java.util.Random;
 import java.util.UUID;
 
 public class CamelExchangeTest extends CamelTest {
-    private final String NAME = UUID.randomUUID().toString();
-    private final String ENDPOINT = "seda:" + UUID.randomUUID().toString();
 
-    @Test
-    void shouldBeAbleToConsumeAProducerMessageFromAExchange() throws Exception {
-        final CamelContext camelContext = context();
-        Exchange exchange = new CamelExchange(camelContext, NAME, ENDPOINT);
+  @Test
+  void shouldBeAbleToConsumeAProducerMessageFromAExchange() throws Exception {
+    final CamelContext camelContext = context();
+    final String endpoint = "seda:" + getRandomString();
+    Exchange exchange = new CamelExchange(camelContext, getRandomString(), endpoint);
 
-        try {
-            final TextMessageReceiver messageReceiver = new TextMessageReceiver(2);
+    try {
+      final MockMessageReceiver<String> messageReceiver = new MockMessageReceiver<>(2);
 
-            final Covey<String, String, org.apache.camel.Exchange> covey = CoveyFactory.build(camelContext, ENDPOINT,
-                                                                           messageReceiver,
-                                                                           new TextMessageAdapter(camelContext),
-                                                                           String.class, String.class);
-            exchange.register(covey);
+      final ExchangeSender<org.apache.camel.Exchange> sender = ExchangeSenders.sendingTo(endpoint, camelContext);
 
-            final String msg1 = UUID.randomUUID().toString();
-            final String msg2 = UUID.randomUUID().toString();
-            exchange.send(msg1);
-            exchange.send(msg2);
+      final Covey<String, String, org.apache.camel.Exchange> covey = CoveyFactory.build(sender,
+                                                                                        messageReceiver,
+                                                                                        new TextMessageAdapter(camelContext),
+                                                                                        String.class,
+                                                                                        String.class);
+      exchange.register(covey);
 
-            final Queue<Object> results = messageReceiver.getResults();
+      final String msg1 = getRandomString();
+      final String msg2 = getRandomString();
+      exchange.send(msg1);
+      exchange.send(msg2);
 
-            Assert.assertEquals(2, results.size());
-            Assert.assertEquals(msg1, results.poll());
-            Assert.assertEquals(msg2, results.poll());
+      final Queue<String> results = messageReceiver.getResults();
 
-        } finally {
-            exchange.close();
-        }
+      Assert.assertEquals(2, results.size());
+      Assert.assertEquals(msg1, results.poll());
+      Assert.assertEquals(msg2, results.poll());
+
+    } finally {
+      exchange.close();
     }
+  }
+
+  @Test
+  void shouldSupportMultipleCoveys() throws Exception {
+    final CamelContext camelContext = context();
+    final String endpoint = "seda:" + "multiple_covey_test";
+    Exchange exchange = new CamelExchange(camelContext, getRandomString(), endpoint);
+
+    try {
+      final ExchangeSender<org.apache.camel.Exchange> sender = ExchangeSenders.sendingTo(endpoint, camelContext);
+
+      final MockMessageReceiver<MessageTypeA> typeAReceiver = new MockMessageReceiver<>(1);
+      exchange.register(CoveyFactory.build(sender, typeAReceiver, new MessageTypeA.Adapter(camelContext), MessageTypeA.class, MessageTypeA.class));
+
+      final MockMessageReceiver<MessageTypeB> typeBReceiver = new MockMessageReceiver<>(1);
+      exchange.register(CoveyFactory.build(sender, typeBReceiver, new MessageTypeB.Adapter(camelContext), MessageTypeB.class, MessageTypeB.class));
+
+      final MockMessageReceiver<MessageTypeC> typeCReceiver = new MockMessageReceiver<>(1);
+      exchange.register(CoveyFactory.build(sender, typeCReceiver, new MessageTypeC.Adapter(camelContext), MessageTypeC.class, MessageTypeC.class));
+
+      final Random random = new Random();
+
+      final MessageTypeA msgA = new MessageTypeA(getRandomString(), getRandomString());
+      final MessageTypeB msgB = new MessageTypeB(getRandomString(), random.nextLong());
+      final MessageTypeC msgC = new MessageTypeC(getRandomString(), new MessageTypeC.NestedMessage(getRandomString(), random.nextInt()));
+
+      exchange.send(msgA);
+      exchange.send(msgB);
+      exchange.send(msgC);
+
+      final Queue<MessageTypeA> resultsTypeA = typeAReceiver.getResults();
+      final Queue<MessageTypeB> resultsTypeB = typeBReceiver.getResults();
+      final Queue<MessageTypeC> resultsTypeC = typeCReceiver.getResults();
+
+      Assert.assertEquals(1, resultsTypeA.size());
+      Assert.assertEquals(1, resultsTypeB.size());
+      Assert.assertEquals(1, resultsTypeC.size());
+
+      Assert.assertEquals(msgA, resultsTypeA.poll());
+      Assert.assertEquals(msgB, resultsTypeB.poll());
+      Assert.assertEquals(msgC, resultsTypeC.poll());
+    } finally {
+      exchange.close();
+    }
+
+  }
+
+  private String getRandomString() {
+    return UUID.randomUUID().toString();
+  }
 }

--- a/src/test/java/io/vlingo/lattice/exchange/camel/e2e/MockMessageReceiver.java
+++ b/src/test/java/io/vlingo/lattice/exchange/camel/e2e/MockMessageReceiver.java
@@ -5,7 +5,7 @@
 // was not distributed with this file, You can obtain
 // one at https://mozilla.org/MPL/2.0/.
 
-package io.vlingo.lattice.exchange.camel;
+package io.vlingo.lattice.exchange.camel.e2e;
 
 import io.vlingo.actors.testkit.AccessSafely;
 import io.vlingo.lattice.exchange.ExchangeReceiver;
@@ -13,23 +13,23 @@ import io.vlingo.lattice.exchange.ExchangeReceiver;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
-public class TextMessageReceiver implements ExchangeReceiver<String> {
+public class MockMessageReceiver<T> implements ExchangeReceiver<T> {
   private final AccessSafely accessSafely;
   private final Queue<Object> results = new ConcurrentLinkedQueue<>();
 
-  public TextMessageReceiver(final int expectedMessages) {
+  public MockMessageReceiver(final int expectedMessages) {
     accessSafely = AccessSafely.afterCompleting(expectedMessages);
     accessSafely.writingWith("results", results::add);
     accessSafely.readingWith("results", () -> results);
   }
 
   @Override
-  public void receive(final String message) {
+  public void receive(final T message) {
     accessSafely.writeUsing("results", message);
   }
 
 
-  public Queue<Object> getResults(){
+  public Queue<T> getResults(){
     return accessSafely.readFrom("results");
   }
 }

--- a/src/test/java/io/vlingo/lattice/exchange/camel/e2e/model/MessageTypeA.java
+++ b/src/test/java/io/vlingo/lattice/exchange/camel/e2e/model/MessageTypeA.java
@@ -1,0 +1,45 @@
+package io.vlingo.lattice.exchange.camel.e2e.model;
+
+import io.vlingo.lattice.exchange.camel.adapter.JsonCamelExchangeAdapter;
+import org.apache.camel.CamelContext;
+
+import java.util.Objects;
+
+public class MessageTypeA {
+  private final String id;
+  private final String message;
+
+  public MessageTypeA(final String id, final String message) {
+    this.id = id;
+    this.message = message;
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public String getMessage() {
+    return message;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o)
+      return true;
+    if (o == null || getClass() != o.getClass())
+      return false;
+    final MessageTypeA that = (MessageTypeA) o;
+    return id.equals(that.id) && message.equals(that.message);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id, message);
+  }
+
+  public static class Adapter extends JsonCamelExchangeAdapter<MessageTypeA, MessageTypeA> {
+    public Adapter(final CamelContext camelContext) {
+      super(camelContext, MessageTypeA.class);
+    }
+  }
+}

--- a/src/test/java/io/vlingo/lattice/exchange/camel/e2e/model/MessageTypeB.java
+++ b/src/test/java/io/vlingo/lattice/exchange/camel/e2e/model/MessageTypeB.java
@@ -1,0 +1,47 @@
+package io.vlingo.lattice.exchange.camel.e2e.model;
+
+import io.vlingo.lattice.exchange.camel.adapter.JsonCamelExchangeAdapter;
+import org.apache.camel.CamelContext;
+
+import java.util.Objects;
+
+public class MessageTypeB {
+  private final String id;
+  private final Long value;
+
+  public MessageTypeB(final String id, final Long value) {
+    this.id = id;
+    this.value = value;
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public Long getValue() {
+    return value;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o)
+      return true;
+    if (o == null || getClass() != o.getClass())
+      return false;
+    final MessageTypeB that = (MessageTypeB) o;
+    return id.equals(that.id) && value.equals(that.value);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id, value);
+  }
+
+  public static class Adapter extends JsonCamelExchangeAdapter<MessageTypeB, MessageTypeB> {
+
+    public Adapter(final CamelContext camelContext) {
+      super(camelContext, MessageTypeB.class);
+    }
+
+  }
+}

--- a/src/test/java/io/vlingo/lattice/exchange/camel/e2e/model/MessageTypeC.java
+++ b/src/test/java/io/vlingo/lattice/exchange/camel/e2e/model/MessageTypeC.java
@@ -1,0 +1,80 @@
+package io.vlingo.lattice.exchange.camel.e2e.model;
+
+import io.vlingo.lattice.exchange.camel.adapter.JsonCamelExchangeAdapter;
+import org.apache.camel.CamelContext;
+
+import java.util.Objects;
+
+public class MessageTypeC {
+  private final String id;
+  private final NestedMessage nestedMsg;
+
+  public MessageTypeC(final String id, final NestedMessage nestedMsg) {
+    this.id = id;
+    this.nestedMsg = nestedMsg;
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public NestedMessage getNestedMsg() {
+    return nestedMsg;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o)
+      return true;
+    if (o == null || getClass() != o.getClass())
+      return false;
+    final MessageTypeC that = (MessageTypeC) o;
+    return id.equals(that.id) && nestedMsg.equals(that.nestedMsg);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id, nestedMsg);
+  }
+
+  public static class NestedMessage {
+    private final String value;
+    private final Integer id;
+
+    public NestedMessage(final String value, final Integer id) {
+      this.value = value;
+      this.id = id;
+    }
+
+    public String getValue() {
+      return value;
+    }
+
+    public Integer getId() {
+      return id;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+      if (this == o)
+        return true;
+      if (o == null || getClass() != o.getClass())
+        return false;
+      final NestedMessage that = (NestedMessage) o;
+      return value.equals(that.value) && id.equals(that.id);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(value, id);
+    }
+  }
+
+  public static class Adapter extends JsonCamelExchangeAdapter<MessageTypeC, MessageTypeC> {
+
+    public Adapter(final CamelContext camelContext) {
+      super(camelContext, MessageTypeC.class);
+    }
+
+  }
+}

--- a/src/test/java/io/vlingo/lattice/exchange/camel/integration/SQSIntegrationTest.java
+++ b/src/test/java/io/vlingo/lattice/exchange/camel/integration/SQSIntegrationTest.java
@@ -34,6 +34,6 @@ public class SQSIntegrationTest extends CamelTestWithDockerIntegration<LocalStac
                 .build();
 
         camelRegistry().bind("client", sqs);
-        return String.format("aws-sqs://%s?amazonSQSClient=#client&delay=5000&maxMessagesPerPoll=5", QUEUE_NAME);
+        return String.format("aws-sqs://%s?amazonSQSClient=#client&delay=5000&maxMessagesPerPoll=5&attributeNames=VlingoExchangeMessageType&messageAttributeNames=VlingoExchangeMessageType", QUEUE_NAME);
     }
 }


### PR DESCRIPTION
Added a special Header, `VlingoExchangeMessageType ` to each Camel Message. 
The header will set by Exchange adapters that extend `AbstractCamelExchangeAdapter ` and will be used by each Covey adapter to verify if message is supported.