### PR TITLE
Bump camel-rabbitmq from 3.0.1 to 3.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
   <properties>
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.source>1.8</maven.compiler.source>
-    <version.camel>3.0.1</version.camel>
+    <version.camel>3.2.0</version.camel>
     <version.junit>5.5.1</version.junit>
     <version.testcontainers>1.16.2</version.testcontainers>
     <version.lombok>1.18.8</version.lombok>

--- a/src/test/java/io/vlingo/xoom/lattice/exchange/camel/CamelTestWithDockerIntegration.java
+++ b/src/test/java/io/vlingo/xoom/lattice/exchange/camel/CamelTestWithDockerIntegration.java
@@ -47,6 +47,7 @@ public abstract class CamelTestWithDockerIntegration<T extends GenericContainer>
   public void shouldConsumeAndReadTheSameMessageFromTheSameExchange() throws Exception {
     String exchangeUri = exchangeUri(container);
     final CamelContext camelContext = context();
+    configureCamelContext(camelContext, container);
     Exchange exchange = new CamelExchange(context(), exchangeUri, exchangeUri);
 
     try {
@@ -73,5 +74,8 @@ public abstract class CamelTestWithDockerIntegration<T extends GenericContainer>
     } finally {
       exchange.close();
     }
+  }
+
+  protected void configureCamelContext(final CamelContext context, final T container) {
   }
 }

--- a/src/test/java/io/vlingo/xoom/lattice/exchange/camel/integration/ActiveMQIntegrationTest.java
+++ b/src/test/java/io/vlingo/xoom/lattice/exchange/camel/integration/ActiveMQIntegrationTest.java
@@ -9,9 +9,12 @@ package io.vlingo.xoom.lattice.exchange.camel.integration;
 
 import java.util.UUID;
 
+import org.apache.camel.CamelContext;
 import org.testcontainers.containers.GenericContainer;
 
 import io.vlingo.xoom.lattice.exchange.camel.CamelTestWithDockerIntegration;
+
+import static org.apache.camel.component.activemq.ActiveMQComponent.activeMQComponent;
 
 @SuppressWarnings("rawtypes")
 public class ActiveMQIntegrationTest extends CamelTestWithDockerIntegration {
@@ -26,6 +29,11 @@ public class ActiveMQIntegrationTest extends CamelTestWithDockerIntegration {
 
     @Override
     protected String exchangeUri(GenericContainer activeMQ) {
-        return String.format("activemq:queue:%s?brokerURL=auto://%s:%d", QUEUE_NAME, activeMQ.getContainerIpAddress(), activeMQ.getMappedPort(61616));
+        return String.format("activemq:queue:%s", QUEUE_NAME);
+    }
+
+    @Override
+    protected void configureCamelContext(final CamelContext context, final GenericContainer activeMQ) {
+        context.addComponent("activemq", activeMQComponent(String.format("auto://%s:%d", activeMQ.getContainerIpAddress(), activeMQ.getMappedPort(61616))));
     }
 }

--- a/src/test/java/io/vlingo/xoom/lattice/exchange/camel/integration/SQSIntegrationTest.java
+++ b/src/test/java/io/vlingo/xoom/lattice/exchange/camel/integration/SQSIntegrationTest.java
@@ -16,6 +16,7 @@ import com.amazonaws.services.sqs.AmazonSQS;
 import com.amazonaws.services.sqs.AmazonSQSClientBuilder;
 
 import io.vlingo.xoom.lattice.exchange.camel.CamelTestWithDockerIntegration;
+import org.testcontainers.utility.DockerImageName;
 
 public class SQSIntegrationTest extends CamelTestWithDockerIntegration<LocalStackContainer> {
     private static final String QUEUE_NAME = UUID.randomUUID().toString();
@@ -23,7 +24,7 @@ public class SQSIntegrationTest extends CamelTestWithDockerIntegration<LocalStac
     @Override
     @SuppressWarnings("resource")
     protected LocalStackContainer testContainer() {
-        return new LocalStackContainer()
+        return new LocalStackContainer(DockerImageName.parse("localstack/localstack:0.11.2"))
                 .withServices(LocalStackContainer.Service.SQS);
     }
 

--- a/src/test/java/io/vlingo/xoom/lattice/exchange/camel/integration/SQSIntegrationTest.java
+++ b/src/test/java/io/vlingo/xoom/lattice/exchange/camel/integration/SQSIntegrationTest.java
@@ -24,7 +24,7 @@ public class SQSIntegrationTest extends CamelTestWithDockerIntegration<LocalStac
     @Override
     @SuppressWarnings("resource")
     protected LocalStackContainer testContainer() {
-        return new LocalStackContainer(DockerImageName.parse("localstack/localstack:0.11.2"))
+        return new LocalStackContainer(DockerImageName.parse("localstack/localstack:0.13.2"))
                 .withServices(LocalStackContainer.Service.SQS);
     }
 


### PR DESCRIPTION
replaces https://github.com/vlingo/xoom-lattice-exchange-camel/pull/6