### PR TITLE
Downgrade camel to the latest version that works with Java 1.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
   <properties>
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.source>1.8</maven.compiler.source>
-    <version.camel>3.8.0</version.camel>
+    <version.camel>3.14.10</version.camel>
     <version.junit>5.5.1</version.junit>
     <version.testcontainers>1.20.2</version.testcontainers>
     <version.lombok>1.18.8</version.lombok>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <version.camel>3.8.0</version.camel>
     <version.junit>5.5.1</version.junit>
-    <version.testcontainers>1.17.2</version.testcontainers>
+    <version.testcontainers>1.20.2</version.testcontainers>
     <version.lombok>1.18.8</version.lombok>
     <graalvm.version>21.1.0</graalvm.version>
   </properties>
@@ -100,7 +100,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.camel</groupId>
-      <artifactId>camel-aws-sqs</artifactId>
+      <artifactId>camel-aws2-sqs</artifactId>
       <version>${version.camel}</version>
       <scope>test</scope>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.camel</groupId>
-      <artifactId>camel-rabbitmq</artifactId>
+      <artifactId>camel-spring-rabbitmq</artifactId>
       <version>${version.camel}</version>
       <scope>test</scope>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
   <properties>
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.source>1.8</maven.compiler.source>
-    <version.camel>3.21.4</version.camel>
+    <version.camel>3.8.0</version.camel>
     <version.junit>5.5.1</version.junit>
     <version.testcontainers>1.17.2</version.testcontainers>
     <version.lombok>1.18.8</version.lombok>

--- a/src/test/java/io/vlingo/xoom/lattice/exchange/camel/integration/RabbitMQIntegrationTest.java
+++ b/src/test/java/io/vlingo/xoom/lattice/exchange/camel/integration/RabbitMQIntegrationTest.java
@@ -9,6 +9,7 @@ package io.vlingo.xoom.lattice.exchange.camel.integration;
 
 import java.util.UUID;
 
+import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
 import org.testcontainers.containers.GenericContainer;
 
 import io.vlingo.xoom.lattice.exchange.camel.CamelTestWithDockerIntegration;
@@ -27,6 +28,8 @@ public class RabbitMQIntegrationTest extends CamelTestWithDockerIntegration {
 
     @Override
     protected String exchangeUri(GenericContainer rabbitMQ) {
-        return String.format("rabbitmq:%s?addresses=%s:%s,", QUEUE_NAME, rabbitMQ.getHost(), rabbitMQ.getMappedPort(5672));
+        camelRegistry().bind("rabbitConnectionFactory",
+                new CachingConnectionFactory(rabbitMQ.getHost(), rabbitMQ.getMappedPort(5672)));
+        return String.format("spring-rabbitmq:%s?connectionFactory=#rabbitConnectionFactory&autoDeclare=true", QUEUE_NAME);
     }
 }

--- a/src/test/java/io/vlingo/xoom/lattice/exchange/camel/integration/SQSIntegrationTest.java
+++ b/src/test/java/io/vlingo/xoom/lattice/exchange/camel/integration/SQSIntegrationTest.java
@@ -50,6 +50,6 @@ public class SQSIntegrationTest extends CamelTestWithDockerIntegration<LocalStac
                 .build();
 
         camelRegistry().bind("client", sqs);
-        return String.format("aws2-sqs://%s?amazonSQSClient=#client&delay=5000&maxMessagesPerPoll=5&attributeNames=VlingoExchangeMessageType&messageAttributeNames=VlingoExchangeMessageType", QUEUE_NAME);
+        return String.format("aws2-sqs://%s?amazonSQSClient=#client&delay=5000&autoCreateQueue=true&maxMessagesPerPoll=5&attributeNames=VlingoExchangeMessageType&messageAttributeNames=VlingoExchangeMessageType", QUEUE_NAME);
     }
 }


### PR DESCRIPTION
Migration to camel-aws2-sqs is needed to get a more up-to-date version.

I also migrated camel-rabbitmq to camel-spring-rabbitmq as the former package is abandoned.

 Unfortunately, the latest camel dependencies are not available for Java 1.8. The latest that targets Java 1.8 is 3.14.10.
